### PR TITLE
feat: add hoangndst as approver of kusion

### DIFF
--- a/APPROVERS.md
+++ b/APPROVERS.md
@@ -1,0 +1,7 @@
+# KusionStack Approvers
+
+The following is the list of approvers in KusionStack community, in alphabetical order: 
+
+| Approver                | GitHub ID                                               | Project                                          | Affiliation                                          |
+|---------------------------|---------------------------------------------------------|--------------------------------------------------------|------------------------------------------------------|
+| Nguyen Dinh Hoang             | [hoangndst](https://github.com/hoangndst)                 | Kusion                                    | Viettel Group               |


### PR DESCRIPTION
Since the first PR submitted on Jun 27 ([#1189](https://github.com/KusionStack/kusion/pull/1189)), @hoangndst has been very active in KusionStack community, implementing the optimization of imported resources ([#1239](https://github.com/KusionStack/kusion/pull/1239) and [#1260](https://github.com/KusionStack/kusion/pull/1260)), the support for `Viettel Cloud` Secrets Manager ([#1267](https://github.com/KusionStack/kusion/pull/1267)), and the `kusion release show` command ([#1265](https://github.com/KusionStack/kusion/pull/1265)). 

I believe @hoangndst has the ability to independently review and merge codes into the Kusion repository, and take responsibility for Kusion's major features. Thus I nominate @hoangndst as an **Approver** for [Kusion](https://github.com/KusionStack/kusion). 

I have added the main maintainers of Kusion repository as the reviewers for this nomination. If you also approve @hoangndst to be an Approver for Kusion, please leave a thumb-up (👍) on this comment before **Sep 15**. 